### PR TITLE
Fixes display buffer problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/hiedb.el
+++ b/hiedb.el
@@ -115,8 +115,13 @@
       (call-process "hiedb" nil t t
                     "-D" hiedb-dbfile cmd
                     mod (format "%d" sline) (format "%d" scol)))
-    (display-buffer-pop-up-window log-buffer nil)
-    (special-mode)))
+    (read-only-mode 1)
+    (display-buffer log-buffer
+                    '(display-buffer-pop-up-window . ((side . top)
+                                                      (window-height . 5)
+                                                      (mode . (special-mode))
+                                                      )))
+    ))
 
 (defun hiedb-reindex ()
   (let*
@@ -135,7 +140,12 @@
                     :buffer log-buffer
                     :command (list "hiedb" "-D" hiedb-dbfile "index" hiedb-hiefiles)
                     :stderr log-buffer))
-    (display-buffer-pop-up-window log-buffer nil)))
+    (read-only-mode 1)
+    (display-buffer log-buffer
+                    '(display-buffer-pop-up-window . ((side . top)
+                                                      (window-height . 5)
+                                                      (mode . (special-mode))
+                                                      )))))
 
 ;; Utilities
 


### PR DESCRIPTION
`display-buffer-pop-up-window` does not seem work all the time - it may
or may not pop up a window, in particular when there are already many
windows opening.

I changed the way to call `display-buffer-pop-up-window`, plus config
the window parameter. Turns out it works constantly now - will display
buffer at bottom and can be cancel (hidden) by pressing Esc or Ctrl-G.